### PR TITLE
The error reported by the SSL layer has changed

### DIFF
--- a/src/test/java/org/certificatetransparency/ctlog/comm/SslConnectionCheckingTest.java
+++ b/src/test/java/org/certificatetransparency/ctlog/comm/SslConnectionCheckingTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLHandshakeException;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
@@ -102,6 +103,10 @@ public class SslConnectionCheckingTest {
           break;
         default:
           fail(String.format("Unexpected HTTP status code: %d", statusCode));
+      }
+    } catch (SSLHandshakeException e) {
+      if (shouldPass) {
+        fail(urlString + " " + e.toString());
       }
     } catch (IOException e) {
       fail(e.toString());


### PR DESCRIPTION
The error reported by the SSL layer has changed when hitting https://invalid-expected-sct.badssl.com/